### PR TITLE
disable marketplace-data download testing

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -669,7 +669,6 @@ orgs.newOrg('adoptium') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: null,
           required_status_checks+: [
-            "call-adoptium-verifier / download-testing",
             "call-adoptium-verifier / validate"
           ],
           requires_approving_reviews: false,


### PR DESCRIPTION
it's been disabled here: https://github.com/adoptium/marketplace-data/pull/111