### PR TITLE
Create temurin-vdr-generator repo

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -303,7 +303,6 @@ orgs.newOrg('adoptium') {
       description: "Home of test infrastructure for Adoptium builds",
       homepage: "https://adoptium.net/aqavit",
       topics+: [
-        "hacktoberfest",
         "openjdk-tests",
         "tests"
       ],
@@ -723,6 +722,17 @@ orgs.newOrg('adoptium') {
         orgs.newBranchProtectionRule('main') {
           required_approving_review_count: 1,
         },
+      ],
+    },
+    orgs.newRepo('temurin-vdr-generator') {
+      allow_auto_merge: true,
+      default_branch: "main",
+      description: "Scripts for generating Vulnerability Disclosure Reports",
+      topics+: [
+        "secure-dev"
+      ],
+      branch_protection_rules: [
+        orgs.newBranchProtectionRule('main'),
       ],
     },
     newBinaryRepo('temurin11-binaries') {},

--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -726,7 +726,6 @@ orgs.newOrg('adoptium') {
     },
     orgs.newRepo('temurin-vdr-generator') {
       allow_auto_merge: true,
-      default_branch: "main",
       description: "Scripts for generating Vulnerability Disclosure Reports",
       topics+: [
         "secure-dev"


### PR DESCRIPTION
A new repo to contain the Vulnerability Disclosure Report generation scripts (related: https://github.com/adoptium/temurin/issues/1 and https://github.com/adoptium/adoptium/issues/209)