### PR TITLE
Create jdk22u mirror repository

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -579,7 +579,9 @@ orgs.newOrg('adoptium') {
       archived: true
     },
     newMirrorRepo('jdk21u') {},
-    newMirrorRepo('jdk22') {},
+    newMirrorRepo('jdk22') {
+      archived: true
+    },
     newMirrorRepo('jdk22u') {},
     newMirrorRepo('jdk8u') {},
     newMirrorRepo('jdk8u_hg') {

--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -580,6 +580,7 @@ orgs.newOrg('adoptium') {
     },
     newMirrorRepo('jdk21u') {},
     newMirrorRepo('jdk22') {},
+    newMirrorRepo('jdk22u') {},
     newMirrorRepo('jdk8u') {},
     newMirrorRepo('jdk8u_hg') {
       archived: true,


### PR DESCRIPTION
Upstream jdk22 development has moved for jdk22u, so we need to be able to mirror that one to build the release later this month.