### PR TITLE
Add temurin24 binaries repo

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -766,6 +766,7 @@ orgs.newOrg('adoptium') {
     newBinaryRepo('temurin21-binaries') {},
     newBinaryRepo('temurin22-binaries') {},
     newBinaryRepo('temurin23-binaries') {},
+    newBinaryRepo('temurin24-binaries') {},
     newBinaryRepo('temurin8-binaries') {},
   ],
 }


### PR DESCRIPTION
jdk-23 has branched, and tip builds are now jdk-24
