### PR TITLE
Add jdk23u adoptium mirror

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -578,6 +578,7 @@ orgs.newOrg('adoptium') {
       archived: true
     },
     newMirrorRepo('jdk22u') {},
+    newMirrorRepo('jdk23u') {},
     newMirrorRepo('jdk8u') {},
     newMirrorRepo('jdk8u_hg') {
       archived: true,


### PR DESCRIPTION
jdk-23.0.1 for October is the latest "updates" version for jdk-23.
This PR adds a new Adoptium mirrir for the https://github.com/openjdk/jdk23u upstream repo