### PR TITLE
Add secrets repo

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -208,9 +208,6 @@ orgs.newOrg('adoptium') {
         orgs.newRepoSecret('AZURE_TENANT_ID') {
           value: "pass:bots/adoptium/azure/azure-tenant-id",
         },
-        orgs.newRepoSecret('DIGITALOCEAN_ACCESS_TOKEN') {
-          value: "pass:bots/adoptium/digitalocean.com/access-token",
-        },
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('production') {

--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -362,6 +362,7 @@ orgs.newOrg('adoptium') {
     orgs.newRepo('secrets') {
       description: "The Secrets Repo for Eclipse Adoptium",
       private: true,
+      allow_forking: false,
     },
     orgs.newRepo('ci-jenkins-pipelines') {
       allow_auto_merge: true,

--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -208,6 +208,9 @@ orgs.newOrg('adoptium') {
         orgs.newRepoSecret('AZURE_TENANT_ID') {
           value: "pass:bots/adoptium/azure/azure-tenant-id",
         },
+        orgs.newRepoSecret('DIGITALOCEAN_ACCESS_TOKEN') {
+          value: "pass:bots/adoptium/digitalocean.com/access-token",
+        },
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('production') {
@@ -358,6 +361,10 @@ orgs.newOrg('adoptium') {
         "java",
         "performance"
       ],
+    },
+    orgs.newRepo('secrets') {
+      description: "The Secrets Repo for Eclipse Adoptium",
+      private: true,
     },
     orgs.newRepo('ci-jenkins-pipelines') {
       allow_auto_merge: true,


### PR DESCRIPTION
Migrating https://github.com/AdoptOpenJDK/secrets to Adoptium, the end goal is to archive this repo and move everything to Bitwarden but for now it makes sense to keep it