### PR TITLE
Set release branch protection with approve reviews 2

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -408,6 +408,9 @@ orgs.newOrg('adoptium') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('master'),
+        orgs.newBranchProtectionRule('v20*') {
+          required_approving_review_count: 2,
+        },
       ],
     },
     newTemurinRepo('containers') {
@@ -619,6 +622,9 @@ orgs.newOrg('adoptium') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('master'),
+        orgs.newBranchProtectionRule('v20*') {
+          required_approving_review_count: 2,
+        },
       ],
       custom_properties+: {
         eclipse_project: "adoptium.temurin",
@@ -742,6 +748,9 @@ orgs.newOrg('adoptium') {
       ],
       branch_protection_rules: [
         orgs.newBranchProtectionRule('master'),
+        orgs.newBranchProtectionRule('v20*') {
+          required_approving_review_count: 2,
+        },
       ],
     },
     newTemurinRepo('temurin-cpe-generator') {


### PR DESCRIPTION
Fixes https://github.com/adoptium/temurin-build/issues/4045

Ensure build repository release branches "v*" have branch protection with 1 review required
