### PR TITLE
Add temurin25-binaries repo

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -790,6 +790,7 @@ orgs.newOrg('adoptium') {
     newBinaryRepo('temurin22-binaries') {},
     newBinaryRepo('temurin23-binaries') {},
     newBinaryRepo('temurin24-binaries') {},
+    newBinaryRepo('temurin25-binaries') {},
     newBinaryRepo('temurin8-binaries') {},
   ],
 }


### PR DESCRIPTION
Upstream openjdk/jdk has branched jdk24 and created new jdk25 HEAD stream, for which we need a new temurin25-binaries repository.
