### PR TITLE
Add temurin-attestations repository for reproducible build attestations

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -780,6 +780,9 @@ orgs.newOrg('adoptium') {
       description: "Repository for Adoptium OpenJDK DevKit builds",
       has_issues: false,
     },
+    newTemurinRepo('temurin-attestations') {
+      description: "Eclipse Temurin™ attestations for 3rd party secure supply chain claims",
+    },
     newBinaryRepo('temurin11-binaries') {},
     newBinaryRepo('temurin16-binaries') {},
     newBinaryRepo('temurin17-binaries') {},


### PR DESCRIPTION
As part of the reproducible verification build claims issue: https://github.com/adoptium/temurin-build/issues/4054
we are adding this new repository to manage 3rd party CycloneDX CDXA attestation documents published from 3rd parites attesting to the reproducible build of Eclipse Temurin JDK binaries.
