### PR TITLE
Add Codecov token to Adoptium.net-next repo

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -224,8 +224,14 @@ orgs.newOrg('adoptium', 'adoptium') {
           required_approving_review_count: 1,
            required_status_checks+: [
              "Lint Code Base",
+             "Run CI",
              "netlify:netlify/adoptium-next/deploy-preview"
            ],
+        },
+      ],
+      secrets: [
+        orgs.newRepoSecret('CODECOV_TOKEN') {
+          value: "pass:bots/adoptium/codecov/adoptium-next-token",
         },
       ],
     },


### PR DESCRIPTION
I can provide the token to EF staff to be added to the vault