### PR TITLE
Add temurin26-binaries

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -867,6 +867,7 @@ orgs.newOrg('adoptium', 'adoptium') {
     newBinaryRepo('temurin23-binaries') {},
     newBinaryRepo('temurin24-binaries') {},
     newBinaryRepo('temurin25-binaries') {},
+    newBinaryRepo('temurin26-binaries') {},
     newBinaryRepo('temurin8-binaries') {},
     newBinaryRepo('temurin-linux-pkg-sources') {},
   ],


### PR DESCRIPTION
openjdk/jdk head is now jdk-26, we need to start Adoptium builds and thus need a temurin26-binaries
