### PR TITLE
Rename temurin-attestations to temurin-cdxa

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -853,6 +853,7 @@ orgs.newOrg('adoptium', 'adoptium') {
       has_issues: false,
     },
     newTemurinRepo('temurin-cdxa') {
+      aliases: ['temurin-attestations'],
       description: "Eclipse Temurin™ CDXA repository for 3rd party secure supply chain claims",
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main'),

--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -852,8 +852,8 @@ orgs.newOrg('adoptium', 'adoptium') {
       description: "Repository for Adoptium OpenJDK DevKit builds",
       has_issues: false,
     },
-    newTemurinRepo('temurin-attestations') {
-      description: "Eclipse Temurin™ attestations for 3rd party secure supply chain claims",
+    newTemurinRepo('temurin-cdxa') {
+      description: "Eclipse Temurin™ CDXA repository for 3rd party secure supply chain claims",
       branch_protection_rules: [
         orgs.newBranchProtectionRule('main'),
       ],


### PR DESCRIPTION
Fixes https://github.com/adoptium/.eclipsefdn/issues/96

As per referenced issue temurin-attestations github repository is to be renamed to temurin-cdxa
