### PR TITLE
Apply dismisses_stale_reviews as default for all Adoptium branch protection rules

### DIFF
--- a/otterdog/adoptium.jsonnet
+++ b/otterdog/adoptium.jsonnet
@@ -7,8 +7,14 @@ local newAdoptiumRepo(name) = orgsOrig.newRepo(name) {
   web_commit_signoff_required: false,
 };
 
+// Set Adoptium specific default branch protection rules here
+local newAdoptiumBranchProtectionRule(branch) = orgsOrig.newBranchProtectionRule(branch) {
+  dismisses_stale_reviews: true,
+};
+
 local orgs = (import 'vendor/otterdog-defaults/otterdog-defaults.libsonnet') + {
-  newRepo::newAdoptiumRepo
+  newRepo::newAdoptiumRepo,
+  newBranchProtectionRule::newAdoptiumBranchProtectionRule
 };
 
 local newTemurinRepo(repoName) = orgs.newRepo(repoName) {


### PR DESCRIPTION
Fixes https://github.com/adoptium/.eclipsefdn/issues/103

As agreed in the PMC, all Adoptium PR reviews should be invalidated if a subsequent new commit is pushed.
